### PR TITLE
Fix error prototypes

### DIFF
--- a/src/errors/InvalidResourceError.ts
+++ b/src/errors/InvalidResourceError.ts
@@ -8,6 +8,7 @@ export class InvalidResourceError extends Error {
     constructor(message = 'Invalid Resource') {
         // Node Error class requires passing a string message to the parent class
         super(message);
+        Object.setPrototypeOf(this, InvalidResourceError.prototype);
         this.name = this.constructor.name;
     }
 }

--- a/src/errors/ResourceNotFoundError.ts
+++ b/src/errors/ResourceNotFoundError.ts
@@ -13,6 +13,7 @@ export class ResourceNotFoundError extends Error {
         const msg = message || `Resource ${resourceType}/${id} is not known`;
         // Node Error class requires passing a string message to the parent class
         super(msg);
+        Object.setPrototypeOf(this, ResourceNotFoundError.prototype);
         this.resourceType = resourceType;
         this.id = id;
         this.name = this.constructor.name;

--- a/src/errors/ResourceVersionNotFoundError.ts
+++ b/src/errors/ResourceVersionNotFoundError.ts
@@ -15,6 +15,7 @@ export class ResourceVersionNotFoundError extends Error {
         const msg = message || `Version "${version}" is not valid for resource ${resourceType}/${id}`;
         // Node Error class requires passing a string message to the parent class
         super(msg);
+        Object.setPrototypeOf(this, ResourceVersionNotFoundError.prototype);
         this.resourceType = resourceType;
         this.id = id;
         this.version = version;


### PR DESCRIPTION
Description of changes:

Turns out that extending built-in types such as `Error` requires special treatment. When integrating the different packages this was breaking our error handling since `instanceof` was not behaving as expected.

See: https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work

I don't fully understand why this used to work before splitting the code into multiple packages...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.