### PR TITLE
docs: Update open api response/request

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -331,7 +331,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ResourceRequest'
+              $ref: '#/components/schemas/ResourceCreateRequest'
       responses:
         '201':
           description: Created
@@ -417,7 +417,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ResourceRequest'
+              $ref: '#/components/schemas/ResourceUpdateRequest'
       responses:
         '200':
           description: Updated
@@ -506,7 +506,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ResourceRequest'
+              $ref: '#/components/schemas/ResourceUpdateRequest'
       responses:
         '200':
           description: Patched
@@ -897,10 +897,14 @@ components:
       properties:
         resource:
           type: object
+          additionalProperties:
+            type: string
           properties:
             id:
               type: string
               description: 'Unique id of the created resource'
+            resourceType:
+              type: string
       description: A generic response for a successful operation. Response should include the full resource along with a required id field for the resource.
     Reference:
       required:
@@ -934,8 +938,25 @@ components:
           description: Where to find the reference in the Bundle entry
           example: provider.reference
       description: A connection between entries in a Bundle
-    ResourceRequest:
+    ResourceCreateRequest:
+      required:
+        - resourceType
+      type: object
+      additionalProperties:
+        type: string
       properties:
+        resourceType:
+          type: string
+    ResourceUpdateRequest:
+      required:
+        - id
+        - resourceType
+      type: object
+      additionalProperties:
+        type: string
+      properties:
+        id:
+          type: string
         resourceType:
           type: string
     ConditionalResourceRequest:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -900,7 +900,7 @@ components:
           properties:
             id:
               type: string
-              description: 'Unique id of the created resource. Should be in uuidv4 format'
+              description: 'Unique id of the created resource'
       description: A generic response for a successful operation. Response should include the full resource along with a required id field for the resource.
     Reference:
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -897,8 +897,7 @@ components:
       properties:
         resource:
           type: object
-          additionalProperties:
-            type: string
+          additionalProperties: true
           properties:
             id:
               type: string
@@ -942,8 +941,7 @@ components:
       required:
         - resourceType
       type: object
-      additionalProperties:
-        type: string
+      additionalProperties: true
       properties:
         resourceType:
           type: string
@@ -952,8 +950,7 @@ components:
         - id
         - resourceType
       type: object
-      additionalProperties:
-        type: string
+      additionalProperties: true
       properties:
         id:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -897,7 +897,11 @@ components:
       properties:
         resource:
           type: object
-      description: A generic response for a successful operation
+          properties:
+            id:
+              type: string
+              description: 'Unique id of the created resource. Should be in uuidv4 format'
+      description: A generic response for a successful operation. Response should include the full resource along with a required id field for the resource.
     Reference:
       required:
         - id
@@ -928,12 +932,12 @@ components:
         referencePath:
           type: string
           description: Where to find the reference in the Bundle entry
-          example: 'provider.reference'
+          example: provider.reference
       description: A connection between entries in a Bundle
     ResourceRequest:
       properties:
-        resource:
-          type: object
+        resourceType:
+          type: string
     ConditionalResourceRequest:
       properties:
         resource:


### PR DESCRIPTION
Description of changes:
* When making a request to CREATE/UPDATE a resource instead of nesting the resource in the object like
```
{
    resource: {
        resourceType: 'Patient'
        ...
   }
}
```
let's just include the resource at the top level like 
```
{
   resourceType: 'Patient'
   ...
}
```

* The response for a resource should include an `id` as a part of the resource that is being returned

What the API looks like in swagger
https://app.swaggerhub.com/apis/nguyen102/FullFWoAApi/3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.