### PR TITLE
feat: add custom errors type guards

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,3 +16,4 @@ tsconfig.json
 .github
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
+CODEOWNERS

--- a/src/errors/InvalidResourceError.ts
+++ b/src/errors/InvalidResourceError.ts
@@ -5,10 +5,19 @@
 
 // eslint-disable-next-line import/prefer-default-export
 export class InvalidResourceError extends Error {
+    readonly isInvalidResourceError: boolean;
+
     constructor(message = 'Invalid Resource') {
         // Node Error class requires passing a string message to the parent class
         super(message);
         Object.setPrototypeOf(this, InvalidResourceError.prototype);
+        this.isInvalidResourceError = true;
         this.name = this.constructor.name;
     }
+}
+export function isInvalidResourceError(err: InvalidResourceError | Error): err is InvalidResourceError {
+    return (
+        (err as InvalidResourceError).isInvalidResourceError !== undefined &&
+        (err as InvalidResourceError).isInvalidResourceError
+    );
 }

--- a/src/errors/InvalidResourceError.ts
+++ b/src/errors/InvalidResourceError.ts
@@ -15,9 +15,6 @@ export class InvalidResourceError extends Error {
         this.name = this.constructor.name;
     }
 }
-export function isInvalidResourceError(err: InvalidResourceError | unknown): err is InvalidResourceError {
-    return (
-        (err as InvalidResourceError).isInvalidResourceError !== undefined &&
-        (err as InvalidResourceError).isInvalidResourceError === true
-    );
+export function isInvalidResourceError(error: unknown): error is InvalidResourceError {
+    return Boolean(error) && (error as InvalidResourceError).isInvalidResourceError === true;
 }

--- a/src/errors/InvalidResourceError.ts
+++ b/src/errors/InvalidResourceError.ts
@@ -15,9 +15,9 @@ export class InvalidResourceError extends Error {
         this.name = this.constructor.name;
     }
 }
-export function isInvalidResourceError(err: InvalidResourceError | Error): err is InvalidResourceError {
+export function isInvalidResourceError(err: InvalidResourceError | unknown): err is InvalidResourceError {
     return (
         (err as InvalidResourceError).isInvalidResourceError !== undefined &&
-        (err as InvalidResourceError).isInvalidResourceError
+        (err as InvalidResourceError).isInvalidResourceError === true
     );
 }

--- a/src/errors/ResourceNotFoundError.ts
+++ b/src/errors/ResourceNotFoundError.ts
@@ -22,9 +22,9 @@ export class ResourceNotFoundError extends Error {
         this.isResourceNotFoundError = true;
     }
 }
-export function isResourceNotFoundError(err: ResourceNotFoundError | Error): err is ResourceNotFoundError {
+export function isResourceNotFoundError(err: ResourceNotFoundError | unknown): err is ResourceNotFoundError {
     return (
         (err as ResourceNotFoundError).isResourceNotFoundError !== undefined &&
-        (err as ResourceNotFoundError).isResourceNotFoundError
+        (err as ResourceNotFoundError).isResourceNotFoundError === true
     );
 }

--- a/src/errors/ResourceNotFoundError.ts
+++ b/src/errors/ResourceNotFoundError.ts
@@ -22,9 +22,6 @@ export class ResourceNotFoundError extends Error {
         this.isResourceNotFoundError = true;
     }
 }
-export function isResourceNotFoundError(err: ResourceNotFoundError | unknown): err is ResourceNotFoundError {
-    return (
-        (err as ResourceNotFoundError).isResourceNotFoundError !== undefined &&
-        (err as ResourceNotFoundError).isResourceNotFoundError === true
-    );
+export function isResourceNotFoundError(error: unknown): error is ResourceNotFoundError {
+    return Boolean(error) && (error as ResourceNotFoundError).isResourceNotFoundError === true;
 }

--- a/src/errors/ResourceNotFoundError.ts
+++ b/src/errors/ResourceNotFoundError.ts
@@ -5,6 +5,8 @@
 
 // eslint-disable-next-line import/prefer-default-export
 export class ResourceNotFoundError extends Error {
+    readonly isResourceNotFoundError: boolean;
+
     readonly resourceType: string;
 
     readonly id: string;
@@ -17,5 +19,12 @@ export class ResourceNotFoundError extends Error {
         this.resourceType = resourceType;
         this.id = id;
         this.name = this.constructor.name;
+        this.isResourceNotFoundError = true;
     }
+}
+export function isResourceNotFoundError(err: ResourceNotFoundError | Error): err is ResourceNotFoundError {
+    return (
+        (err as ResourceNotFoundError).isResourceNotFoundError !== undefined &&
+        (err as ResourceNotFoundError).isResourceNotFoundError
+    );
 }

--- a/src/errors/ResourceVersionNotFoundError.ts
+++ b/src/errors/ResourceVersionNotFoundError.ts
@@ -25,11 +25,6 @@ export class ResourceVersionNotFoundError extends Error {
         this.isResourceVersionNotFoundError = true;
     }
 }
-export function isResourceVersionNotFoundError(
-    err: ResourceVersionNotFoundError | unknown,
-): err is ResourceVersionNotFoundError {
-    return (
-        (err as ResourceVersionNotFoundError).isResourceVersionNotFoundError !== undefined &&
-        (err as ResourceVersionNotFoundError).isResourceVersionNotFoundError === true
-    );
+export function isResourceVersionNotFoundError(error: unknown): error is ResourceVersionNotFoundError {
+    return Boolean(error) && (error as ResourceVersionNotFoundError).isResourceVersionNotFoundError === true;
 }

--- a/src/errors/ResourceVersionNotFoundError.ts
+++ b/src/errors/ResourceVersionNotFoundError.ts
@@ -26,10 +26,10 @@ export class ResourceVersionNotFoundError extends Error {
     }
 }
 export function isResourceVersionNotFoundError(
-    err: ResourceVersionNotFoundError | Error,
+    err: ResourceVersionNotFoundError | unknown,
 ): err is ResourceVersionNotFoundError {
     return (
         (err as ResourceVersionNotFoundError).isResourceVersionNotFoundError !== undefined &&
-        (err as ResourceVersionNotFoundError).isResourceVersionNotFoundError
+        (err as ResourceVersionNotFoundError).isResourceVersionNotFoundError === true
     );
 }

--- a/src/errors/ResourceVersionNotFoundError.ts
+++ b/src/errors/ResourceVersionNotFoundError.ts
@@ -5,6 +5,8 @@
 
 // eslint-disable-next-line import/prefer-default-export
 export class ResourceVersionNotFoundError extends Error {
+    readonly isResourceVersionNotFoundError: boolean;
+
     readonly resourceType: string;
 
     readonly id: string;
@@ -20,5 +22,14 @@ export class ResourceVersionNotFoundError extends Error {
         this.id = id;
         this.version = version;
         this.name = this.constructor.name;
+        this.isResourceVersionNotFoundError = true;
     }
+}
+export function isResourceVersionNotFoundError(
+    err: ResourceVersionNotFoundError | Error,
+): err is ResourceVersionNotFoundError {
+    return (
+        (err as ResourceVersionNotFoundError).isResourceVersionNotFoundError !== undefined &&
+        (err as ResourceVersionNotFoundError).isResourceVersionNotFoundError
+    );
 }

--- a/src/errors/UnauthorizedError.ts
+++ b/src/errors/UnauthorizedError.ts
@@ -1,0 +1,22 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+// eslint-disable-next-line import/prefer-default-export
+export class UnauthorizedError extends Error {
+    readonly isUnauthorizedError: boolean;
+
+    constructor(message = 'Forbidden') {
+        // Node Error class requires passing a string message to the parent class
+        super(message);
+        Object.setPrototypeOf(this, UnauthorizedError.prototype);
+        this.name = this.constructor.name;
+        this.isUnauthorizedError = true;
+    }
+}
+export function isUnauthorizedError(err: UnauthorizedError | Error): err is UnauthorizedError {
+    return (
+        (err as UnauthorizedError).isUnauthorizedError !== undefined && (err as UnauthorizedError).isUnauthorizedError
+    );
+}

--- a/src/errors/UnauthorizedError.ts
+++ b/src/errors/UnauthorizedError.ts
@@ -15,9 +15,6 @@ export class UnauthorizedError extends Error {
         this.isUnauthorizedError = true;
     }
 }
-export function isUnauthorizedError(err: UnauthorizedError | unknown): err is UnauthorizedError {
-    return (
-        (err as UnauthorizedError).isUnauthorizedError !== undefined &&
-        (err as UnauthorizedError).isUnauthorizedError === true
-    );
+export function isUnauthorizedError(error: unknown): error is UnauthorizedError {
+    return Boolean(error) && (error as UnauthorizedError).isUnauthorizedError === true;
 }

--- a/src/errors/UnauthorizedError.ts
+++ b/src/errors/UnauthorizedError.ts
@@ -15,8 +15,9 @@ export class UnauthorizedError extends Error {
         this.isUnauthorizedError = true;
     }
 }
-export function isUnauthorizedError(err: UnauthorizedError | Error): err is UnauthorizedError {
+export function isUnauthorizedError(err: UnauthorizedError | unknown): err is UnauthorizedError {
     return (
-        (err as UnauthorizedError).isUnauthorizedError !== undefined && (err as UnauthorizedError).isUnauthorizedError
+        (err as UnauthorizedError).isUnauthorizedError !== undefined &&
+        (err as UnauthorizedError).isUnauthorizedError === true
     );
 }


### PR DESCRIPTION
Description of changes:
- With many potential interface versions we need a consistent way to identify our errors
- This follows a paradigm set by moment.js
https://stackoverflow.com/questions/41587865/using-instanceof-on-objects-created-with-constructors-from-deep-npm-dependenci/41592087#41592087

This fixes the current problem of if the sub-packages depend on differing versions of the interface

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.