### PR TITLE
fix: fix exportedFileUrls type

### DIFF
--- a/src/bulkDataAccess.ts
+++ b/src/bulkDataAccess.ts
@@ -11,7 +11,7 @@ export interface InitiateExportRequest {
 export interface GetExportStatusResponse {
     jobStatus: ExportJobStatus;
     jobOwnerId: string;
-    exportedFileUrls?: [{ type: string; url: string }];
+    exportedFileUrls?: { type: string; url: string }[];
     transactionTime?: string;
     exportType?: ExportType;
     outputFormat?: string; // query _outputFormat, required to allow building of request url, https://hl7.org/Fhir/uv/bulkdata/export/index.html#query-parameters


### PR DESCRIPTION
Description of changes:
exportedFileUrls should be an array of objects

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.