### PR TITLE
feat: explicitly define required OAuth urls

### DIFF
--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -3,15 +3,23 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { FhirVersion, TypeOperation, R4Resource, STU3Resource, SystemOperation, ConfigVersion } from './constants';
-import { Persistence } from './persistence';
-import { History } from './history';
-import { Search } from './search';
 import { Authorization } from './authorization';
 import { Bundle } from './bundle';
+import { ConfigVersion, FhirVersion, R4Resource, STU3Resource, SystemOperation, TypeOperation } from './constants';
+import { History } from './history';
+import { Persistence } from './persistence';
+import { Search } from './search';
+
+export interface OAuthStrategy {
+    oauthAuthorizationUrl: string;
+    oauthTokenUrl: string;
+    oauthPublicKeyUrl?: string;
+    oauthTokenIntrospectionUrl?: string;
+    oauthUserInfoUrl?: string;
+}
 
 export interface Strategy {
-    oauthUrl?: string;
+    oauth?: OAuthStrategy;
     // https://www.hl7.org/fhir/codesystem-restful-security-service.html
     service?: 'OAuth' | 'SMART-on-FHIR' | 'NTLM' | 'Basic' | 'Kerberos' | 'Certificates';
 }


### PR DESCRIPTION
Description of changes:
In the case of Auth0 the token and authorize urls do not share the exact same base.

Ex)
https://some-tenant.us.auth0.com/oauth/token
https://some-tenant.us.auth0.com/authorize

This change splits them out so they can be configured separately.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.