### PR TITLE
fix: change OAuth Strategy param names

### DIFF
--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -11,11 +11,11 @@ import { Persistence } from './persistence';
 import { Search } from './search';
 
 export interface OAuthStrategy {
-    oauthAuthorizationUrl: string;
-    oauthTokenUrl: string;
-    oauthPublicKeyUrl?: string;
-    oauthTokenIntrospectionUrl?: string;
-    oauthUserInfoUrl?: string;
+    authorizationUrl: string;
+    tokenUrl: string;
+    publicKeyUrl?: string;
+    tokenIntrospectionUrl?: string;
+    userInfoUrl?: string;
 }
 
 export interface Strategy {


### PR DESCRIPTION
Description of changes:
- remove `oauth` prefix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.