### PR TITLE
feat: modify authz interface

### DIFF
--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -7,7 +7,7 @@ import { BatchReadWriteRequest } from './bundle';
 import { TypeOperation, SystemOperation } from './constants';
 import { ExportType } from './bulkDataAccess';
 
-export interface AuthorizationRequest {
+export interface VerifyAccessTokenRequest {
     accessToken: string;
     operation: TypeOperation | SystemOperation;
     resourceType?: string;
@@ -29,53 +29,49 @@ export interface BulkDataAuth {
 }
 
 export interface AuthorizationBundleRequest {
-    accessToken: string;
+    userIdentity: object;
     requests: BatchReadWriteRequest[];
 }
 
 export interface AllowedResourceTypesForOperationRequest {
-    accessToken: string;
+    userIdentity: object;
     operation: TypeOperation | SystemOperation;
 }
 
 export interface AccessBulkDataJobRequest {
-    requesterUserId: string;
+    userIdentity: object;
     jobOwnerId: string;
 }
 
 export interface ReadResponseAuthorizedRequest {
-    accessToken: string;
+    userIdentity: object;
     operation: TypeOperation | SystemOperation;
     readResponse: any;
 }
 
 export interface WriteRequestAuthorizedRequest {
-    accessToken: string;
+    userIdentity: object;
     operation: TypeOperation;
     resourceBody: any;
 }
 
 export interface Authorization {
     /**
-     * Validates if the requester is authorized to perform the action requested
+     * Validates the access_tokne and returns the userIdentity
+     * @returns decoded access_token; effectively the userIdentity
      * @throws UnauthorizedError
      */
-    isAuthorized(request: AuthorizationRequest): Promise<void>;
+    verifyAccessToken(request: VerifyAccessTokenRequest): Promise<object>;
     /**
      * Used to authorize Bundle transactions
      * @throws UnauthorizedError
      */
     isBundleRequestAuthorized(request: AuthorizationBundleRequest): Promise<void>;
-
     /*
      * Used to determine if a requester can access a Bulk Data Job
+     * @throws UnauthorizedError
      */
-    isAccessBulkDataJobAllowed(request: AccessBulkDataJobRequest): void;
-
-    /**
-     * Get requester unique userId
-     */
-    getRequesterUserId(accessToken: string): string;
+    isAccessBulkDataJobAllowed(request: AccessBulkDataJobRequest): Promise<void>;
     /**
      * @returns resourceTypes for which the requester is allowed to perform the requested operation.
      */

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -57,7 +57,7 @@ export interface WriteRequestAuthorizedRequest {
 
 export interface Authorization {
     /**
-     * Validates the access_tokne and returns the userIdentity
+     * Validates the access token and returns the userIdentity
      * @returns decoded access_token; effectively the userIdentity
      * @throws UnauthorizedError
      */

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -58,7 +58,7 @@ export interface WriteRequestAuthorizedRequest {
 export interface Authorization {
     /**
      * Validates the access token and returns the userIdentity
-     * @returns decoded access_token; effectively the userIdentity
+     * @returns decoded access token; effectively the userIdentity
      * @throws UnauthorizedError
      */
     verifyAccessToken(request: VerifyAccessTokenRequest): Promise<object>;

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -48,7 +48,9 @@ export module stubs {
 
     export const passThroughAuthz: Authorization = {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        async isAuthorized(request) {},
+        async verifyAccessToken(request) {
+            return {};
+        },
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         async isBundleRequestAuthorized(request) {},
         async authorizeAndFilterReadResponse(request) {
@@ -56,13 +58,8 @@ export module stubs {
         },
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         async isWriteRequestAuthorized(request) {},
-
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        isAccessBulkDataJobAllowed(request: AccessBulkDataJobRequest) {},
-
-        getRequesterUserId(accessToken: string): string {
-            return 'random-userId';
-        },
+        async isAccessBulkDataJobAllowed(request: AccessBulkDataJobRequest) {},
         async getAllowedResourceTypesForOperation(request) {
             return [
                 'Account',


### PR DESCRIPTION
Description of changes:
- rename `isAuthorized` -> `verifyAccessToken`
- Change the paradigm from passing access_token everywhere to passing the decoded access_token (named userIdentity)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.