### PR TITLE
fix: change userIdentity param type

### DIFF
--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -4,7 +4,7 @@
  */
 
 import { BatchReadWriteRequest } from './bundle';
-import { TypeOperation, SystemOperation } from './constants';
+import { TypeOperation, SystemOperation, KeyValueMap } from './constants';
 import { ExportType } from './bulkDataAccess';
 
 export interface VerifyAccessTokenRequest {
@@ -29,28 +29,28 @@ export interface BulkDataAuth {
 }
 
 export interface AuthorizationBundleRequest {
-    userIdentity: object;
+    userIdentity: KeyValueMap;
     requests: BatchReadWriteRequest[];
 }
 
 export interface AllowedResourceTypesForOperationRequest {
-    userIdentity: object;
+    userIdentity: KeyValueMap;
     operation: TypeOperation | SystemOperation;
 }
 
 export interface AccessBulkDataJobRequest {
-    userIdentity: object;
+    userIdentity: KeyValueMap;
     jobOwnerId: string;
 }
 
 export interface ReadResponseAuthorizedRequest {
-    userIdentity: object;
+    userIdentity: KeyValueMap;
     operation: TypeOperation | SystemOperation;
     readResponse: any;
 }
 
 export interface WriteRequestAuthorizedRequest {
-    userIdentity: object;
+    userIdentity: KeyValueMap;
     operation: TypeOperation;
     resourceBody: any;
 }
@@ -61,7 +61,7 @@ export interface Authorization {
      * @returns decoded access token; effectively the userIdentity
      * @throws UnauthorizedError
      */
-    verifyAccessToken(request: VerifyAccessTokenRequest): Promise<object>;
+    verifyAccessToken(request: VerifyAccessTokenRequest): Promise<KeyValueMap>;
     /**
      * Used to authorize Bundle transactions
      * @throws UnauthorizedError

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,8 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
+export type KeyValueMap = { [key: string]: any };
+
 export type IssueSeverity = 'fatal' | 'error' | 'warning' | 'information';
 
 // Codes defined here= https://www.hl7.org/fhir/valueset-issue-type.html


### PR DESCRIPTION
Description of changes:
- `object` is a non-indexable type
- Creating a generic indexable type

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.