### PR TITLE
feat: Support additional product info used in the Capability Statement

### DIFF
--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -112,7 +112,9 @@ export interface Profile {
     genericResource?: GenericResource;
     resources?: Resources;
 }
-
+/**
+   * Used in the generation of the CapabilityStatement
+   */
 export interface ProductInfo {
     orgName: string;
     productVersion?: string;

--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -119,7 +119,10 @@ export interface ProductInfo {
     orgName: string;
     productVersion?: string;
     productName?: string;
-    productSlug?: string;
+/**
+  * Name should be usable as an identifier for the module by machine processing applications such as code generation.
+  */
+    productMachineName?: string;
     productDescription?: string;
     productPurpose?: string;
     copyright?: string;

--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -113,18 +113,43 @@ export interface Profile {
     resources?: Resources;
 }
 /**
-   * Used in the generation of the CapabilityStatement
-   */
+ * Used in the generation of the CapabilityStatement
+ */
 export interface ProductInfo {
+    /**
+     * Name of the organization publishing and operating the solution
+     * See: https://www.hl7.org/fhir/capabilitystatement-definitions.html#CapabilityStatement.publisher
+     */
     orgName: string;
+    /**
+     * An identifier that is used to identify this version of the capability statement.
+     * See: https://www.hl7.org/fhir/capabilitystatement-definitions.html#CapabilityStatement.version
+     */
     productVersion?: string;
-    productName?: string;
-/**
-  * Name should be usable as an identifier for the module by machine processing applications such as code generation.
-  */
-    productMachineName?: string;
+    /**
+     * A short, descriptive, user-friendly title for the capability statement.
+     * See: https://www.hl7.org/fhir/capabilitystatement-definitions.html#CapabilityStatement.title
+     */
+    productTitle?: string;
+    /**
+     * A description of the capability statement from a consumer's perspective.
+     * See: https://www.hl7.org/fhir/capabilitystatement-definitions.html#CapabilityStatement.description
+     */
     productDescription?: string;
+    /**
+     * An identifier for the module to be used by machine processing applications such as code generation.
+     * See: https://www.hl7.org/fhir/capabilitystatement-definitions.html#CapabilityStatement.name
+     */
+    productMachineName?: string;
+    /**
+     * An explanation of the need and design of the capability statement.
+     * See: https://www.hl7.org/fhir/capabilitystatement-definitions.html#CapabilityStatement.purpose
+     */
     productPurpose?: string;
+    /**
+     * A copyright statement relating to the capability statement.
+     * See: https://www.hl7.org/fhir/capabilitystatement-definitions.html#CapabilityStatement.copyright
+     */
     copyright?: string;
 }
 

--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -113,9 +113,19 @@ export interface Profile {
     resources?: Resources;
 }
 
-export interface FhirConfig {
+export interface ProductInfo {
     orgName: string;
+    productVersion?: string;
+    productName?: string;
+    productSlug?: string;
+    productDescription?: string;
+    productPurpose?: string;
+    copyright?: string;
+}
+
+export interface FhirConfig {
     configVersion: ConfigVersion;
+    productInfo: ProductInfo;
     auth: Auth;
     server: Server;
     logging: Logging;


### PR DESCRIPTION
Description of changes:

This change introduces a new `ProductInfo` interface to collect product and business information about the FHIR server. This information is used to further enrich the information found in the CapabilityStatement. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.