### PR TITLE
feature: Adding SearchFilter interface

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { SearchEntry } from './search';
+import { SearchEntry, SearchFilter } from './search';
 
 export interface InstanceHistoryRequest extends TypeHistoryRequest {
     id: string;
@@ -14,8 +14,9 @@ export interface TypeHistoryRequest extends GlobalHistoryRequest {
 }
 
 export interface GlobalHistoryRequest {
-    queryParams?: any;
     baseUrl: string; // server's URL
+    queryParams?: any;
+    searchFilters?: SearchFilter[];
 }
 
 export interface HistoryResponse {

--- a/src/search.ts
+++ b/src/search.ts
@@ -9,8 +9,9 @@ export interface TypeSearchRequest extends GlobalSearchRequest {
 }
 
 export interface GlobalSearchRequest {
-    queryParams?: any;
     baseUrl: string; // server's URL
+    queryParams?: any;
+    searchFilters?: SearchFilter[];
 }
 
 export interface SearchResponse {
@@ -34,6 +35,12 @@ export interface SearchResult {
     previousResultUrl?: string;
     nextResultUrl?: string;
     lastResultUrl?: string;
+}
+
+export interface SearchFilter {
+    filterKey: string;
+    filterValue: string;
+    filterOperator: '~' | '==' | '!=' | '>' | '<' | '>=' | '<=';
 }
 
 export interface Search {

--- a/src/search.ts
+++ b/src/search.ts
@@ -40,7 +40,7 @@ export interface SearchResult {
 export interface SearchFilter {
     key: string;
     value: string[];
-    comparisonOperator: '~' | '==' | '!=' | '>' | '<' | '>=' | '<=';
+    comparisonOperator: '==' | '!=' | '>' | '<' | '>=' | '<=';
     logicalOperator: 'AND' | 'OR';
 }
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -38,9 +38,10 @@ export interface SearchResult {
 }
 
 export interface SearchFilter {
-    filterKey: string;
-    filterValue: string;
-    filterOperator: '~' | '==' | '!=' | '>' | '<' | '>=' | '<=';
+    key: string;
+    value: string[];
+    comparisonOperator: '~' | '==' | '!=' | '>' | '<' | '>=' | '<=';
+    logicalOperator: 'AND' | 'OR';
 }
 
 export interface Search {


### PR DESCRIPTION
Description of changes:

This PR introduces the `SearchFilter` interface and adds a `SearchFilter[]` parameter to the `*HistoryRequest` and `*SearchRequest` interfaces. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.