### PR TITLE
feat: add InvalidSearchParameterError

### DIFF
--- a/src/errors/InvalidSearchParameterError.ts
+++ b/src/errors/InvalidSearchParameterError.ts
@@ -7,7 +7,7 @@
 export class InvalidSearchParameterError extends Error {
     readonly isInvalidSearchParameterError: boolean;
 
-    constructor(message = 'Invalid Resource') {
+    constructor(message: string) {
         // Node Error class requires passing a string message to the parent class
         super(message);
         Object.setPrototypeOf(this, InvalidSearchParameterError.prototype);

--- a/src/errors/InvalidSearchParameterError.ts
+++ b/src/errors/InvalidSearchParameterError.ts
@@ -1,0 +1,20 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+// eslint-disable-next-line import/prefer-default-export
+export class InvalidSearchParameterError extends Error {
+    readonly isInvalidSearchParameterError: boolean;
+
+    constructor(message = 'Invalid Resource') {
+        // Node Error class requires passing a string message to the parent class
+        super(message);
+        Object.setPrototypeOf(this, InvalidSearchParameterError.prototype);
+        this.isInvalidSearchParameterError = true;
+        this.name = this.constructor.name;
+    }
+}
+export function isInvalidSearchParameterError(error: unknown): error is InvalidSearchParameterError {
+    return Boolean(error) && (error as InvalidSearchParameterError).isInvalidSearchParameterError === true;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,5 @@ export * from './errors/ResourceNotFoundError';
 export * from './errors/ResourceVersionNotFoundError';
 export * from './errors/UnauthorizedError';
 export * from './errors/TooManyConcurrentExportRequestsError';
+export * from './errors/InvalidSearchParameterError';
 export { stubs } from './stubs';


### PR DESCRIPTION
Description of changes:

Add a new error for search to throw when search parameters are invalid. i.e. `{{API_URL}}/Patient?some-invalid-param=value`
It will ultimately map to a 400 error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.