### PR TITLE
fix: Include history-instance as part of operations for GetSearchFilterBasedOnIdentityRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [6.0.1] - 2021-01-06
+
+### Updated
+* `GetSearchFilterBasedOnIdentityRequest.operation` now includes `history-instance`
+
 ## [6.0.0] - 2020-12-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-works-on-aws-interface",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "FHIR Works on AWS hosted on AWS Lambda",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -58,7 +58,7 @@ export interface WriteRequestAuthorizedRequest {
 
 export interface GetSearchFilterBasedOnIdentityRequest {
     userIdentity: KeyValueMap;
-    operation: 'search-type' | 'search-system' | 'history-type' | 'history-system';
+    operation: 'search-type' | 'search-system' | 'history-type' | 'history-system' | 'history-instance';
 }
 
 export interface Authorization {


### PR DESCRIPTION
Description of changes:
fix: Include history-instance as part of operations for GetSearchFilterBasedOnIdentityRequest

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.