### PR TITLE
feat: add getCapabilities method to Search interface

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -51,9 +51,9 @@ export interface SearchCapabilityStatement {
 export interface SearchCapabilities {
     searchParam: {
         name: string;
-        definition: string;
+        definition?: string;
         type: string;
-        documentation: string;
+        documentation?: string;
     }[];
     searchInclude: string[];
     searchRevInclude: string[];

--- a/src/search.ts
+++ b/src/search.ts
@@ -69,7 +69,8 @@ export interface Search {
      */
     globalSearch(request: GlobalSearchRequest): Promise<SearchResponse>;
     /**
-     * Returns the fragment of the CapabilityStatement related to search
+     * Retrieve a subset of the CapabilityStatement with the search-related fields for all resources
+     * See https://www.hl7.org/fhir/capabilitystatement.html
      */
     getCapabilities(): Promise<SearchCapabilityStatement>;
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -44,6 +44,21 @@ export interface SearchFilter {
     logicalOperator: 'AND' | 'OR';
 }
 
+export interface SearchCapabilityStatement {
+    [resourceType: string]: SearchCapabilities;
+}
+
+export interface SearchCapabilities {
+    searchParam: {
+        name: string;
+        definition: string;
+        type: string;
+        documentation: string;
+    }[];
+    searchInclude: string[];
+    searchRevInclude: string[];
+}
+
 export interface Search {
     /**
      * Searches a specific Resource Type based on some filter criteria
@@ -53,4 +68,8 @@ export interface Search {
      * Searches all Resource Types based on some filter criteria
      */
     globalSearch(request: GlobalSearchRequest): Promise<SearchResponse>;
+    /**
+     * Returns the fragment of the CapabilityStatement related to search
+     */
+    getCapabilities(): Promise<SearchCapabilityStatement>;
 }

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -4,7 +4,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Search } from './search';
+import { Search, SearchCapabilityStatement } from './search';
 import { History } from './history';
 import { AccessBulkDataJobRequest, Authorization, GetSearchFilterBasedOnIdentityRequest } from './authorization';
 import { Persistence } from './persistence';
@@ -23,6 +23,9 @@ export module stubs {
     };
 
     export const search: Search = {
+        async getCapabilities(): Promise<SearchCapabilityStatement> {
+            throw new Error('Method not implemented.');
+        },
         typeSearch(request) {
             throw new Error('Method not implemented.');
         },


### PR DESCRIPTION
Description of changes:

The output of `getCapabilities` will be used to build the CapabilityStatement for `/metadata`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.