### PR TITLE
feat: add implementation guides compile interface

### DIFF
--- a/src/implementationGuides.ts
+++ b/src/implementationGuides.ts
@@ -1,0 +1,18 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface ImplementationGuides {
+    /**
+     * Compiles the contents of an Implementation Guide into an internal representation used to implement the features specified by it.
+     *
+     * The FHIR resource types commonly used on Implementation Guides are: StructureDefinition, SearchParameter, CodeSystem, ValueSet, ImplementationGuide, ConceptMap, OperationDefinition, CapabilityStatement.
+     *
+     * Different implementations of this interface may choose to process only a subset of the above resources.
+     *
+     * @param input - an array of FHIR resource objects to be compiled.
+     * @return compiled output - The output is not meant to be used by any other entity other than the module that implements this interface.
+     */
+    compile(input: any[]): Promise<any>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export * from './constants';
 export * from './fhirConfig';
 export * from './genericResponse';
 export * from './history';
+export * from './implementationGuides';
 export * from './persistence';
 export * from './resourceMeta';
 export * from './search';


### PR DESCRIPTION
Description of changes:
Add the interface for compiling IGs. Its a separate interface. FWoA modules(i.e. `fhir-works-on-aws-search-es`) can additionally implement this interface to support IGs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.