### PR TITLE
fix: Add optional parameters to GetSearchFilter

### DIFF
--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -59,6 +59,10 @@ export interface WriteRequestAuthorizedRequest {
 export interface GetSearchFilterBasedOnIdentityRequest {
     userIdentity: KeyValueMap;
     operation: 'search-type' | 'search-system' | 'history-type' | 'history-system' | 'history-instance';
+    /** Used for type and instance based searching */
+    resourceType?: string;
+    /** Used exclusively for `history-instance` operation */
+    id?: string;
 }
 
 export interface Authorization {


### PR DESCRIPTION
Description of changes:

This is required on the SMART on FHIR AuthZ package to determine to add an `id` as an OR filter or not

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.