### PR TITLE
chore!: Remove ttlInSeconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "postinstall": "tsc"
   },
   "dependencies": {
-    "typescript": "^4.1.3"
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
@@ -45,7 +44,8 @@
     "jest-each": "^26.4.2",
     "jest-mock-extended": "^1.0.8",
     "prettier": "^1.19.1",
-    "ts-jest": "^26.4.4"
+    "ts-jest": "^26.4.4",
+    "typescript": "^4.1.3"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "prepublish": "tsc",
     "postinstall": "tsc"
   },
-  "dependencies": {},
+  "dependencies": {
+    "typescript": "^4.1.3"
+  },
   "devDependencies": {
     "@types/jest": "^26.0.19",
     "@types/node": "^12",
@@ -43,8 +45,7 @@
     "jest-each": "^26.4.2",
     "jest-mock-extended": "^1.0.8",
     "prettier": "^1.19.1",
-    "ts-jest": "^26.4.4",
-    "typescript": "^4.1.3"
+    "ts-jest": "^26.4.4"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -28,11 +28,8 @@
     "prepublish": "tsc"
   },
   "dependencies": {
-<<<<<<< HEAD
-=======
     "winston": "^3.3.3",
     "winston-transport": "^4.4.0"
->>>>>>> 1b7765a3a51694c9a11263fa76109cdf0c6e6f47
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "release": "yarn run build && yarn run lint && yarn run test",
     "clean": "rm -rf build/* node_modules/* dist/* .serverless/* .nyc_output/* lib/*",
     "local": "node .",
-    "prepublish": "tsc",
-    "postinstall": "tsc"
+    "prepublish": "tsc"
   },
   "dependencies": {
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "release": "yarn run build && yarn run lint && yarn run test",
     "clean": "rm -rf build/* node_modules/* dist/* .serverless/* .nyc_output/* lib/*",
     "local": "node .",
-    "prepublish": "tsc"
+    "prepublish": "tsc",
+    "postinstall": "tsc"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "postinstall": "tsc"
   },
   "dependencies": {
+    "typescript": "^4.1.3"
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
@@ -44,8 +45,7 @@
     "jest-each": "^26.4.2",
     "jest-mock-extended": "^1.0.8",
     "prettier": "^1.19.1",
-    "ts-jest": "^26.4.4",
-    "typescript": "^4.1.3"
+    "ts-jest": "^26.4.4"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -21,6 +21,7 @@ export interface BatchReadWriteRequest {
     id: string;
     vid?: string;
     resource: any;
+    ttlInSeconds?: number; // archive timestamp in Unix epoch time format in seconds
     // GET requests, only contains the URL of the resource
     fullUrl?: string;
     references?: Reference[];

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -21,7 +21,6 @@ export interface BatchReadWriteRequest {
     id: string;
     vid?: string;
     resource: any;
-    ttlInSeconds?: number; // archive timestamp in Unix epoch time format in seconds
     // GET requests, only contains the URL of the resource
     fullUrl?: string;
     references?: Reference[];

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -9,7 +9,7 @@ export interface CreateResourceRequest {
     resourceType: string;
     resource: any;
     id?: string;
-    ttl?: number; // used for archiving
+    ttlInSeconds?: number; // archive timestamp in Unix epoch time format in seconds
 }
 
 export interface UpdateResourceRequest {
@@ -17,6 +17,7 @@ export interface UpdateResourceRequest {
     resourceType: string;
     resource: any;
     vid?: string; // used in version aware update
+    ttlInSeconds?: number; // archive timestamp in Unix epoch time format in seconds
 }
 
 export interface PatchResourceRequest {
@@ -24,6 +25,7 @@ export interface PatchResourceRequest {
     resourceType: string;
     resource: any;
     vid?: string; // used in version aware patch
+    ttlInSeconds?: number; // archive timestamp in Unix epoch time format in seconds
 }
 
 export interface ReadResourceRequest {

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -9,6 +9,7 @@ export interface CreateResourceRequest {
     resourceType: string;
     resource: any;
     id?: string;
+    ttl?: number; // used for archiving
 }
 
 export interface UpdateResourceRequest {

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -9,7 +9,6 @@ export interface CreateResourceRequest {
     resourceType: string;
     resource: any;
     id?: string;
-    ttlInSeconds?: number; // archive timestamp in Unix epoch time format in seconds
 }
 
 export interface UpdateResourceRequest {
@@ -17,7 +16,6 @@ export interface UpdateResourceRequest {
     resourceType: string;
     resource: any;
     vid?: string; // used in version aware update
-    ttlInSeconds?: number; // archive timestamp in Unix epoch time format in seconds
 }
 
 export interface PatchResourceRequest {
@@ -25,7 +23,6 @@ export interface PatchResourceRequest {
     resourceType: string;
     resource: any;
     vid?: string; // used in version aware patch
-    ttlInSeconds?: number; // archive timestamp in Unix epoch time format in seconds
 }
 
 export interface ReadResourceRequest {


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/fhir-works-on-aws-deployment/issues/290

Description of changes:
Rolling back the addition of ttlInSeconds from persistence and bundle interfaces because we now pass in all configured ttlsInSeconds as a Map<string, number> to the persistence and bundle constructors.

BREAKING CHANGE: Removes ttlInSeconds from the `persistence` interface

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.