### PR TITLE
fix: add missing fhirServiceBaseUrl to AuthorizationBundleRequest

### DIFF
--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -54,6 +54,11 @@ export interface AuthorizationBundleRequest {
     userIdentity: KeyValueMap;
     requestContext?: RequestContext;
     requests: BatchReadWriteRequest[];
+    /**
+     * The FHIR server base URL. It may contain a path in addition to the hostname. See: https://www.hl7.org/fhir/http.html#root
+     * @example https://fhir-server/path
+     */
+    fhirServiceBaseUrl?: string;
 }
 
 export interface AllowedResourceTypesForOperationRequest {


### PR DESCRIPTION
This was missing and is causing multi-tenant bundle requests to sometimes be rejected

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.