### PR TITLE
fix: updating SmartStrategy interface to spec

### DIFF
--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -24,7 +24,7 @@ export interface OAuthStrategy {
     managementEndpoint?: string;
 }
 
-export type tokenEndpointAuthMethod = 'client_secret_basic' | 'client_secret_post';
+export type tokenEndpointAuthMethod = 'client_secret_basic' | 'client_secret_post' | 'private_key_jwt';
 
 /**
  * http://www.hl7.org/fhir/smart-app-launch/conformance/index.html#using-well-known
@@ -63,6 +63,14 @@ export interface SmartStrategy extends OAuthStrategy {
      * array of client authentication methods supported by the token endpoint.
      */
     tokenEndpointAuthMethodsSupported?: tokenEndpointAuthMethod[];
+    /**
+     * array of the supported JSON web signature algorithms for the token endpoint
+     */
+    tokenEndpointAuthSigningAlgValuesSupported?: string[];
+    /**
+     * URL of the dynamic client registration endpoint
+     */
+    registrationEndpoint?: string;
 }
 
 export interface Strategy {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Referencing the [SMART Backend Services: Authorization Guide](http://hl7.org/fhir/uv/bulkdata/authorization/index.html#advertising-server-conformance-with-smart-backend-services)

1. Updated SmartStrategy interface to include two additional (optional) attributes. 
2. added an additional auth method 'private_key_jwt' 

There did not appear to be any specified list of signing algorithms allowed for SMART or oidc in general so I defaulted to let the support signing algorithms attribute expect an array of strings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.