### PR TITLE
feat: add requiresAccessToken to GetExportStatusResponse

### DIFF
--- a/src/bulkDataAccess.ts
+++ b/src/bulkDataAccess.ts
@@ -26,6 +26,7 @@ export interface InitiateExportRequest {
 export interface GetExportStatusResponse {
     jobStatus: ExportJobStatus;
     jobOwnerId: string;
+    requiresAccessToken?: boolean;
     exportedFileUrls?: { type: string; url: string }[];
     transactionTime?: string;
     exportType?: ExportType;


### PR DESCRIPTION
We are adding flexibility to how the export results URLs are generated and we need `requiresAccessToken` to be dynamic.
Currently the `requiresAccessToken` field is hard-coded to `false` in the router response.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.