### PR TITLE
feat: add sessionId to search requests

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -15,6 +15,10 @@ export interface GlobalSearchRequest {
     queryParams?: any;
     searchFilters?: SearchFilter[];
     tenantId?: string;
+    /**
+     * An optional session identifier. Search implementations may use this value to optimize search queries.
+     */
+    sessionId?: string;
 }
 
 export interface TypeSearchRequest extends GlobalSearchRequest {


### PR DESCRIPTION
Issue #, if available: https://github.com/awslabs/fhir-works-on-aws-search-es/issues/128

The `sessionId` will ultimately be used as the [Elasticsearch preference parameter](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#search-preference) to fix the "bouncing results" issue

- https://www.elastic.co/guide/en/elasticsearch/guide/current/_search_options.html#_preferencehttps://www.elastic.co/guide/en/elasticsearch/reference/current/search-shard-routing.html#shard-and-node-preference
- https://www.elastic.co/guide/en/elasticsearch/guide/current/_search_options.html#_preference

Related PR:
- https://github.com/awslabs/fhir-works-on-aws-search-es/pull/130
- https://github.com/awslabs/fhir-works-on-aws-routing/pull/140


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.