### PR TITLE
feat!: add methods to persistence and search interface for subscription

### DIFF
--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -131,4 +131,11 @@ export interface Persistence {
      * the appropriate action to take.
      */
     conditionalDeleteResource(request: ConditionalDeleteResourceRequest, queryParams: any): Promise<GenericResponse>;
+
+    /**
+     * This method should return an array of all the active Subscriptions.
+     * If a tenantId is passed as parameter, it should scope the results to only the Subscriptions owned by that tenant.
+     * @param params
+     */
+    getActiveSubscriptions(params: { tenantId?: string }): Promise<Record<string, any>[]>;
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -82,5 +82,5 @@ export interface Search {
      * Verify that a search string use as criteria in Subscription resource is valid
      * and does not use _revinclude, _include, _sort, _count and chained parameter
      */
-    isSubscriptionSearchCriteriaValid(searchCriteria: string): Boolean;
+    isSubscriptionSearchCriteriaValid(searchCriteria: string): boolean;
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -79,8 +79,7 @@ export interface Search {
      */
     getCapabilities(): Promise<SearchCapabilityStatement>;
     /**
-     * Verify that a search string use as criteria in Subscription resource is valid
-     * and does not use _revinclude, _include, _sort, _count and chained parameter
+     * Verify that a search string used as criteria in Subscription resource is valid
      */
-    isSubscriptionSearchCriteriaValid(searchCriteria: string): boolean;
+    isSubscriptionSearchCriteriaValid(searchCriteria: string): void;
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -78,4 +78,9 @@ export interface Search {
      * See https://www.hl7.org/fhir/capabilitystatement.html
      */
     getCapabilities(): Promise<SearchCapabilityStatement>;
+    /**
+     * Verify that a search string use as criteria in Subscription resource is valid
+     * and does not use _revinclude, _include, _sort, _count and chained parameter
+     */
+    isSubscriptionSearchCriteriaValid(searchCriteria: string): Boolean;
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -81,5 +81,5 @@ export interface Search {
     /**
      * Verify that a search string used as criteria in Subscription resource is valid
      */
-    isSubscriptionSearchCriteriaValid(searchCriteria: string): void;
+    validateSubscriptionSearchCriteria(searchCriteria: string): void;
 }

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -34,7 +34,7 @@ export module stubs {
             throw new Error('Method not implemented.');
         },
 
-        isSubscriptionSearchCriteriaValid(searchCriteria) {
+        validateSubscriptionSearchCriteria(searchCriteria) {
             throw new Error('Method not implemented.');
         },
     };

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -33,6 +33,10 @@ export module stubs {
         globalSearch(request) {
             throw new Error('Method not implemented.');
         },
+
+        isSubscriptionSearchCriteriaValid(searchCriteria) {
+            throw new Error('Method not implemented.');
+        },
     };
 
     export const history: History = {
@@ -256,6 +260,10 @@ export module stubs {
         },
 
         conditionalDeleteResource(request, queryParams) {
+            throw new Error('Method not implemented.');
+        },
+
+        getActiveSubscriptions(params) {
             throw new Error('Method not implemented.');
         },
     };

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -3,5 +3,5 @@ export interface Validator {
      * returns a resolved Promise if the resource is valid. Otherwise throws an error
      * @throws InvalidResourceError
      */
-    validate(resource: any): Promise<void>;
+    validate(resource: any, tenantId?: string): Promise<void>;
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Add `isSubscriptionSearchCriteriaValid(searchCriteria: string): Boolean;` to search 
* Add `getActiveSubscriptions(params: { tenantId?: string }): Promise<Record<string, any>[]>;` to persistence 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.