### PR TITLE
feat: Feature/private api gateway

### DIFF
--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -12,7 +12,7 @@ export type CapabilityMode = 'full' | 'normative' | 'terminology';
 export interface CapabilitiesRequest {
     fhirVersion: FhirVersion;
     mode: CapabilityMode;
-    hostName?: string;
+    fhirServiceBaseUrl?: string;
 }
 
 export interface Capabilities {

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -12,6 +12,7 @@ export type CapabilityMode = 'full' | 'normative' | 'terminology';
 export interface CapabilitiesRequest {
     fhirVersion: FhirVersion;
     mode: CapabilityMode;
+    hostName?: string;
 }
 
 export interface Capabilities {

--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -91,7 +91,7 @@ export interface Server {
     /**
      * replace the url's hostname with the incoming request's host header; usefully when multiple upstream API gateway's or custom DNS
      */
-    dynamicHostName?: boolean 
+    dynamicHostName?: boolean;
 }
 
 export interface Resource {

--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -88,6 +88,7 @@ export interface Auth {
 
 export interface Server {
     url: string;
+    alternativeUrls?: string[]
 }
 
 export interface Resource {

--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -88,7 +88,10 @@ export interface Auth {
 
 export interface Server {
     url: string;
-    alternativeUrls?: string[]
+    /**
+     * replace the url's hostname with the incoming request's host header; usefully when multiple upstream API gateway's or custom DNS
+     */
+    dynamicHostName?: boolean 
 }
 
 export interface Resource {


### PR DESCRIPTION
Issue #, if available: https://github.com/awslabs/fhir-works-on-aws-deployment/issues/378

Description of changes: 
Adding dynamicHostName to the config.server's interface to support the dynamic creation of API_URLs when upstream to the fhir-server lambda can be multiple API gateway's or custom DNS values in use. Similarly, the metadata endpoint's handler will now have hostname passed so it can compute a dynamic implementation.url value if configured to do so.

Related PRs:
- https://github.com/awslabs/fhir-works-on-aws-routing/pull/153

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.