### PR TITLE
Feature/multi tenancy addons

### DIFF
--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -175,6 +175,16 @@ export interface MultiTenancyConfig {
      * @example "nested.object.tenantId"
      */
     tenantIdClaimPath: string;
+    /**
+     * The prefix helps to identify the tenant specific values in a custom claim.
+     * @example "tenant:" would identify the tenant value "tenant:12345" in "cognito:groups" claim
+     */
+    tenantIdClaimValuePrefix?: string;
+    /**
+     * This optional option specifies a scope, which allows access to all tenants.
+     * This option is only applicable if useTenantSpecificUrl is enabled.
+     */
+    grantAccessAllTenantsScope?: string;
 }
 
 export interface FhirConfig {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
For the integration of FHIRWorks into our product some addons were necessary in regards of multi tenancy.

The following optional parameters were added to the MultiTenancyConfig:
- tenantIdClaimValuePrefix:
  This setting allows to define a certain prefix, in order to mark values as tenant ids, being provided by the tenantIdClaimPath
  It is used in the in the tenant id routing middleware and is configure in fhir-works-on-aws-deployment
- grantAccessAllTenantsScope:
  For machine to machine authn/z e.g. by using client credentials flow, FHIR Works shall be able to distinguish between m2m access token, which grant access to all tenants and user based access, which allows only access to on particular tenant.
This setting allows to specify the value of a scope, which is used in the tenant id routing middleware later-on to distinguish these tokens. The value is configured in fhir-works-on-aws-deployment.
Subsequent PRs on fhir-works-on-aws-routing &  fhir-works-on-aws-deployment will follow after this one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.